### PR TITLE
Add support for quoted assets

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -940,8 +940,14 @@ class TableAsset(_SQLAsset):
         try:
             with engine.connect() as connection:
                 table = sa.table(self.table_name, schema=self.schema_name)
+
+                # sa.select(1, table).limit(1) produces query like this
+                # SELECT * FROM "SPECIAL_CHAR_([{!@#$%^&*_+|:;?/,.~``}])" LIMIT %(param_1)
+                # which checks for %. It finds % in our table name and and try to escape %^ which causes exception
+                # unsupported format character '^'
+
                 # don't need to fetch any data, just want to make sure the table is accessible
-                connection.execute(sa.select(1, table).limit(1))
+                connection.execute(f'SELECT 1 FROM {self.table_name} LIMIT 1')
         except Exception as query_error:
             LOGGER.info(f"{self.name} `.test_connection()` query failed: {query_error!r}")
             raise TestConnectionError(  # noqa: TRY003

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -14,6 +14,7 @@ from typing import (
     Generic,
     List,
     Literal,
+    Mapping,
     Optional,
     Protocol,
     Sequence,
@@ -79,7 +80,6 @@ from great_expectations.execution_engine.partition_and_sample.sqlalchemy_data_pa
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.sql import quoted_name  # noqa: TID251 # type-checking only
 
     from great_expectations.compatibility import sqlalchemy
     from great_expectations.core.batch_definition import BatchDefinition
@@ -91,7 +91,13 @@ if TYPE_CHECKING:
 
 LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
-DEFAULT_QUOTE_CHARACTERS: Final[Tuple[str, str]] = ('"', "'")
+DEFAULT_INITIAL_QUOTE_CHARACTERS: Final[Tuple[str, str, str, str]] = ('"', "'", "`", "[")
+DEFAULT_FINAL_QUOTE_CHARACTERS: Final[Mapping[str, str]] = {
+    '"': '"',
+    "'": "'",
+    "`": "`",
+    "[": "]",
+}
 
 
 @overload
@@ -104,7 +110,7 @@ def to_lower_if_not_quoted(value: None, quote_characters: Sequence[str] = ...) -
 
 def to_lower_if_not_quoted(
     value: str | None,
-    quote_characters: Sequence[str] = DEFAULT_QUOTE_CHARACTERS,
+    quote_characters: Sequence[str] = DEFAULT_INITIAL_QUOTE_CHARACTERS,
 ) -> str | None:
     """
     Convert a string to lowercase if it is not enclosed in quotes.
@@ -112,7 +118,7 @@ def to_lower_if_not_quoted(
     if not value:
         return value
     for char in quote_characters:
-        if value.startswith(char) and value.endswith(char):
+        if value.startswith(char) and value.endswith(DEFAULT_FINAL_QUOTE_CHARACTERS[char]):
             LOGGER.warning(
                 f"The {value} string is bracketed by quotes,"
                 " so it will not be converted to lowercase."
@@ -616,7 +622,7 @@ class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT])
         else:
             sql_partitioner = None
 
-        batch_spec_kwargs: dict[str, str | dict | None]
+        batch_spec_kwargs: Dict[str, str | dict | None]
         requests = self._fully_specified_batch_requests(batch_request)
         unsorted_metadata_dicts = [self._get_batch_metadata_from_batch_request(r) for r in requests]
 
@@ -787,7 +793,7 @@ class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT])
                 f"but actually has form:\n{pf(batch_request.dict())}\n"
             )
 
-    def _create_batch_spec_kwargs(self) -> dict[str, Any]:
+    def _create_batch_spec_kwargs(self) -> Dict[str, Any]:
         """Creates batch_spec_kwargs used to instantiate a SqlAlchemyDatasourceBatchSpec or RuntimeQueryBatchSpec
 
         This is called by get_batch to generate the batch.
@@ -834,7 +840,7 @@ class QueryAsset(_SQLAsset):
         return sa.select(sa.text(self.query.lstrip()[6:])).subquery()
 
     @override
-    def _create_batch_spec_kwargs(self) -> dict[str, Any]:
+    def _create_batch_spec_kwargs(self) -> Dict[str, Any]:
         return {
             "data_asset_name": self.name,
             "query": self.query,
@@ -858,6 +864,8 @@ class TableAsset(_SQLAsset):
     )
     schema_name: Optional[str] = None
 
+    _quote_character: Optional[str] = None
+
     @property
     def qualified_name(self) -> str:
         return f"{self.schema_name}.{self.table_name}" if self.schema_name else self.table_name
@@ -872,8 +880,7 @@ class TableAsset(_SQLAsset):
         return validated_table_name
 
     @pydantic.validator("table_name")
-    def _resolve_quoted_name(cls, table_name: str) -> str | quoted_name:
-        table_name_is_quoted: bool = cls._is_bracketed_by_quotes(table_name)
+    def _resolve_quoted_name(cls, table_name: str, values: Dict[str, Any]) -> str:
 
         from great_expectations.compatibility import sqlalchemy
 
@@ -881,18 +888,37 @@ class TableAsset(_SQLAsset):
             if isinstance(table_name, sqlalchemy.quoted_name):
                 return table_name
 
-            if table_name_is_quoted:
+            quote: bool = cls._is_bracketed_by_quotes(table_name)
+
+            if quote:
                 # https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.quoted_name.quote
                 # Remove the quotes and add them back using the sqlalchemy.quoted_name function
                 # TODO: We need to handle nested quotes
-                table_name = table_name.strip("'").strip('"')
+                values["_quote_character"] = table_name[0]
+                table_name_is_quoted = True
+                table_name = table_name.lstrip("".join(DEFAULT_INITIAL_QUOTE_CHARACTERS)).rstrip(
+                    "".join(DEFAULT_FINAL_QUOTE_CHARACTERS.values())
+                )
 
             return sqlalchemy.quoted_name(
                 value=table_name,
-                quote=table_name_is_quoted,
+                quote=quote,
             )
 
         return table_name
+
+    @override
+    def dict(self, **kwargs) -> Dict[str, Any]:
+        original_dict = super().dict(**kwargs)
+
+        # we need to ensure we retain the quotes when serializing quoted names
+        qc = self._quote_character
+        if qc is not None:
+            original_dict["table_name"] = (
+                f"{qc}{self.table_name}{DEFAULT_FINAL_QUOTE_CHARACTERS[qc]}"
+            )
+
+        return original_dict
 
     @override
     def test_connection(self) -> None:
@@ -929,10 +955,10 @@ class TableAsset(_SQLAsset):
 
         This can be used in a from clause for a query against this data.
         """
-        return sa.text(self.qualified_name)  # type: ignore[return-value]
+        return sa.table(self.table_name, schema=self.schema_name)
 
     @override
-    def _create_batch_spec_kwargs(self) -> dict[str, Any]:
+    def _create_batch_spec_kwargs(self) -> Dict[str, Any]:
         return {
             "type": "table",
             "data_asset_name": self.name,
@@ -942,7 +968,7 @@ class TableAsset(_SQLAsset):
         }
 
     @override
-    def _create_batch_spec(self, batch_spec_kwargs: dict) -> SqlAlchemyDatasourceBatchSpec:
+    def _create_batch_spec(self, batch_spec_kwargs: Dict) -> SqlAlchemyDatasourceBatchSpec:
         return SqlAlchemyDatasourceBatchSpec(**batch_spec_kwargs)
 
     @staticmethod
@@ -960,8 +986,8 @@ class TableAsset(_SQLAsset):
             True if the target string is bracketed by quotes.
         """
         return any(
-            target.startswith(quote) and target.endswith(quote)
-            for quote in DEFAULT_QUOTE_CHARACTERS
+            target.startswith(quote) and target.endswith(DEFAULT_FINAL_QUOTE_CHARACTERS[quote])
+            for quote in DEFAULT_INITIAL_QUOTE_CHARACTERS
         )
 
     @classmethod
@@ -975,7 +1001,7 @@ class TableAsset(_SQLAsset):
         Returns:
             The target string in lowercase if it is not bracketed by quotes.
         """
-        return to_lower_if_not_quoted(target, quote_characters=DEFAULT_QUOTE_CHARACTERS)
+        return to_lower_if_not_quoted(target, quote_characters=DEFAULT_INITIAL_QUOTE_CHARACTERS)
 
 
 def _warn_for_more_specific_datasource_type(connection_string: str) -> None:
@@ -986,7 +1012,7 @@ def _warn_for_more_specific_datasource_type(connection_string: str) -> None:
 
     connector: str = connection_string.split("://")[0].split("+")[0]
 
-    type_lookup_plus: dict[str, str] = {
+    type_lookup_plus: Dict[str, str] = {
         n: DataSourceManager.type_lookup[n].__name__
         for n in DataSourceManager.type_lookup.type_names()
     }

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -381,13 +381,15 @@ def get_sqlalchemy_column_metadata(
                     # Implicit subquery for columns().column was deprecated in SQLAlchemy 1.4
                     # We must explicitly create a subquery
                     columns = table_selectable.columns().subquery().columns
+            elif sqlalchemy.quoted_name and isinstance(table_selectable, sqlalchemy.quoted_name):  # type: ignore[truthy-function]
+                columns = inspector.get_columns(
+                    table_name=table_selectable,
+                    schema=schema_name,
+                )
             else:
-                # TODO: remove cast to a string once [this](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/157) issue is resovled  # noqa: E501
-                table_name = str(table_selectable)
-                if execution_engine.dialect_name == GXSqlDialect.SNOWFLAKE:
-                    table_name = table_name.lower()
+                logger.warning("unexpected table_selectable type")
                 columns = inspector.get_columns(  # type: ignore[assignment]
-                    table_name=table_name,
+                    table_name=str(table_selectable),
                     schema=schema_name,
                 )
         except (

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -13,7 +13,7 @@ from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.datasource.fluent import GxDatasourceWarning, SQLDatasource
 from great_expectations.datasource.fluent.sql_datasource import (
-    DEFAULT_QUOTE_CHARACTERS,
+    DEFAULT_INITIAL_QUOTE_CHARACTERS,
     TableAsset,
     to_lower_if_not_quoted,
 )
@@ -377,19 +377,20 @@ def test_specific_datasource_warnings(
 @pytest.mark.parametrize(
     ["input_", "expected_output", "quote_characters"],
     [
-        ("my_schema", "my_schema", DEFAULT_QUOTE_CHARACTERS),
-        ("MY_SCHEMA", "my_schema", DEFAULT_QUOTE_CHARACTERS),
-        ("My_Schema", "my_schema", DEFAULT_QUOTE_CHARACTERS),
-        ('"my_schema"', '"my_schema"', DEFAULT_QUOTE_CHARACTERS),
-        ('"MY_SCHEMA"', '"MY_SCHEMA"', DEFAULT_QUOTE_CHARACTERS),
-        ('"My_Schema"', '"My_Schema"', DEFAULT_QUOTE_CHARACTERS),
-        ("'my_schema'", "'my_schema'", DEFAULT_QUOTE_CHARACTERS),
-        ("'MY_SCHEMA'", "'MY_SCHEMA'", DEFAULT_QUOTE_CHARACTERS),
-        ("'My_Schema'", "'My_Schema'", DEFAULT_QUOTE_CHARACTERS),
-        (None, None, DEFAULT_QUOTE_CHARACTERS),
-        ("", "", DEFAULT_QUOTE_CHARACTERS),
-        ("`My_Schema`", "`My_Schema`", ("`",)),
-        ("'My_Schema'", "'my_schema'", ("`",)),
+        ("my_schema", "my_schema", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("MY_SCHEMA", "my_schema", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("My_Schema", "my_schema", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ('"my_schema"', '"my_schema"', DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ('"MY_SCHEMA"', '"MY_SCHEMA"', DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ('"My_Schema"', '"My_Schema"', DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'my_schema'", "'my_schema'", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'MY_SCHEMA'", "'MY_SCHEMA'", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'My_Schema'", "'My_Schema'", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        (None, None, DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("", "", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("`My_Schema`", "`My_Schema`", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'My_Schema'", "'my_schema'", ("`")),
+        ("[My_Schema]", "[My_Schema]", DEFAULT_INITIAL_QUOTE_CHARACTERS),
     ],
     ids=lambda x: str(x),
 )
@@ -416,6 +417,23 @@ class TestTableAsset:
         )
         assert table_asset.schema_name == schema_name.lower()
 
+    @pytest.mark.parametrize("table_name", ["my_table", "MY_TABLE", "My_Table"])
+    def test_unquoted_table_names_are_unquoted(
+        self,
+        sql_datasource_table_asset_test_connection_noop: SQLDatasource,
+        table_name: str,
+    ):
+        my_datasource: SQLDatasource = sql_datasource_table_asset_test_connection_noop
+
+        table_asset = my_datasource.add_table_asset(
+            name="my_table_asset",
+            table_name=table_name,
+            schema_name="my_schema",
+        )
+        assert isinstance(table_asset.table_name, sqlalchemy.quoted_name)
+        assert table_asset.table_name == table_name
+        assert not table_asset.table_name.quote
+
     @pytest.mark.parametrize(
         "schema_name",
         [
@@ -425,6 +443,8 @@ class TestTableAsset:
             "'my_schema'",
             "'MY_SCHEMA'",
             "'My_Schema'",
+            "`My_Schema`",
+            "[My_Schema]",
         ],
     )
     def test_quoted_schema_names_are_not_modified(
@@ -440,6 +460,69 @@ class TestTableAsset:
             schema_name=schema_name,
         )
         assert table_asset.schema_name == schema_name
+
+    @pytest.mark.parametrize(
+        "table_name",
+        [
+            '"my_table"',
+            '"MY_TABLE"',
+            '"My_Table"',
+            "'my_table'",
+            "'MY_TABLE'",
+            "'My_Table'",
+            "`my_table`",
+            "[my_table]",
+        ],
+    )
+    def test_quoted_table_names_are_quoted(
+            self,
+            sql_datasource_table_asset_test_connection_noop: SQLDatasource,
+            table_name: str,
+    ):
+        my_datasource: SQLDatasource = sql_datasource_table_asset_test_connection_noop
+
+        table_asset = my_datasource.add_table_asset(
+            name="my_table_asset",
+            table_name=table_name,
+            schema_name="my_schema",
+        )
+        assert isinstance(table_asset.table_name, sqlalchemy.quoted_name)
+        assert table_asset.table_name == table_name[1:-1]
+        assert table_asset.table_name.quote
+
+    @pytest.mark.parametrize(
+        "table_name,serialized_name",
+        [
+            pytest.param('"my_table"', '"my_table"'),
+            pytest.param('"MY_TABLE"', '"MY_TABLE"'),
+            pytest.param('"My_Table"', '"My_Table"'),
+            pytest.param("'my_table'", "'my_table'"),
+            pytest.param("'MY_TABLE'", "'MY_TABLE'"),
+            pytest.param("'My_Table'", "'My_Table'"),
+            pytest.param("[My_Table]", "[My_Table]"),
+            pytest.param("`My_Table`", "`My_Table`"),
+            pytest.param("my_table", "my_table"),
+            pytest.param("MY_TABLE", "MY_TABLE"),
+            pytest.param("My_Table", "My_Table"),
+        ],
+    )
+    def test_table_name_serialization_preserves_quotes(
+            self,
+            table_name: str,
+            serialized_name: str,
+    ):
+        table_asset = TableAsset(name="my_table_asset", table_name=table_name)
+
+        with mock.patch(
+            "great_expectations.datasource.fluent.sql_datasource.TableAsset.datasource",
+            new_callable=mock.PropertyMock,
+            return_value=SQLDatasource(
+                name="my_snowflake_datasource",
+                connection_string="snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>",
+            ),
+        ):
+            serialized = table_asset.dict()
+            assert serialized["table_name"] == table_name
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**

Adds support for quoted table and schema names in SQL datasources, including proper handling of various quote characters (double quotes, single quotes, backticks, and square brackets).

**Changes**

Enhanced to_lower_if_not_quoted function to handle multiple quote character pairs including ", ', `, and [/]
Updated SQL datasource to use raw queries instead of selectable for quoted asset names
Added test coverage for quoted table scenarios